### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ run these binaries. Nix-ld provides a shim layer for these types of binaries. It
 is installed in the same location where other Linux distributions install their
 link loader, ie. `/lib64/ld-linux-x86-64.so.2` and then loads the actual link
 loader as specified in the environment variable `NIX_LD`. In addition, it also
-accepts a comma-separated path from library lookup paths in `NIX_LD_LIBRARY_PATH`.
+accepts a colon-separated path from library lookup paths in `NIX_LD_LIBRARY_PATH`.
 This environment variable is rewritten to `LD_LIBRARY_PATH` before
 passing execution to the actual ld. This allows you to specify additional
 libraries that the executable needs to run.


### PR DESCRIPTION
Environment variables are colon-separated, luckily…